### PR TITLE
Feat/exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+.qodo

--- a/src/main/kotlin/kr/tareun/concert/application/payment/model/PayCommand.kt
+++ b/src/main/kotlin/kr/tareun/concert/application/payment/model/PayCommand.kt
@@ -1,16 +1,19 @@
 package kr.tareun.concert.application.payment.model
 
 import kr.tareun.concert.interfaces.payment.model.PayRequest
+import java.util.UUID
 
 data class PayCommand(
     val userId: Long,
-    val reservationId: Long
+    val reservationId: Long,
+    val tokenUuid: UUID
 ) {
     companion object {
-        fun from(payRequest: PayRequest): PayCommand {
+        fun from(payRequest: PayRequest, tokenUuid: UUID): PayCommand {
             return PayCommand(
                 userId = payRequest.userId,
-                reservationId = payRequest.reservationId
+                reservationId = payRequest.reservationId,
+                tokenUuid = tokenUuid
             )
         }
     }

--- a/src/main/kotlin/kr/tareun/concert/application/queue/QueueService.kt
+++ b/src/main/kotlin/kr/tareun/concert/application/queue/QueueService.kt
@@ -1,6 +1,8 @@
 package kr.tareun.concert.application.queue
 
 import kr.tareun.concert.application.queue.model.QueueTokenResult
+import kr.tareun.concert.common.exception.CommonException
+import kr.tareun.concert.common.exception.ErrorCode
 import kr.tareun.concert.domain.queue.QueueRepository
 import kr.tareun.concert.domain.queue.model.QueueToken
 import kr.tareun.concert.domain.queue.model.TokenStatusType
@@ -22,7 +24,7 @@ class QueueService(
         return when (token.status) {
             TokenStatusType.PENDING -> QueueTokenResult.from(token,  queueRepository.countQueueByIdLessThanAndStatus(token.tokenId, TokenStatusType.PENDING))
             TokenStatusType.ACTIVATED -> QueueTokenResult.from(token, 0)
-            TokenStatusType.EXPIRED -> throw RuntimeException("만료된 토큰입니다.")
+            TokenStatusType.EXPIRED -> throw CommonException(ErrorCode.QUEUE_TOKEN_EXPIRED)
         }
     }
 }

--- a/src/main/kotlin/kr/tareun/concert/application/reservation/ReservationService.kt
+++ b/src/main/kotlin/kr/tareun/concert/application/reservation/ReservationService.kt
@@ -4,6 +4,8 @@ import kr.tareun.concert.application.payment.model.PayCommand
 import kr.tareun.concert.application.payment.model.PaymentHistoryResult
 import kr.tareun.concert.application.reservation.model.ReserveCommand
 import kr.tareun.concert.application.reservation.model.ReservationResult
+import kr.tareun.concert.common.exception.CommonException
+import kr.tareun.concert.common.exception.ErrorCode
 import kr.tareun.concert.domain.concert.ConcertRepository
 import kr.tareun.concert.domain.payment.PaymentRepository
 import kr.tareun.concert.domain.payment.model.PaymentHistory
@@ -27,7 +29,7 @@ class ReservationService(
         // 중복 예약 체크
         val existReservedList = reservationRepository.getAllReservationItemByScheduleIdAndSeatId(reserveCommand.concertScheduleId, reserveCommand.seatIdList)
         if (existReservedList.isNotEmpty()) {
-            throw RuntimeException()
+            throw CommonException(ErrorCode.RESERVATION_SEAT_ALREADY_TAKEN)
         }
 
         val schedule = concertRepository.getScheduleByScheduleId(reserveCommand.concertScheduleId)

--- a/src/main/kotlin/kr/tareun/concert/application/reservation/ReservationService.kt
+++ b/src/main/kotlin/kr/tareun/concert/application/reservation/ReservationService.kt
@@ -7,6 +7,7 @@ import kr.tareun.concert.application.reservation.model.ReservationResult
 import kr.tareun.concert.domain.concert.ConcertRepository
 import kr.tareun.concert.domain.payment.PaymentRepository
 import kr.tareun.concert.domain.payment.model.PaymentHistory
+import kr.tareun.concert.domain.queue.QueueRepository
 import kr.tareun.concert.domain.reservation.ReservationRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,6 +17,7 @@ class ReservationService(
     private val reservationRepository: ReservationRepository,
     private val concertRepository: ConcertRepository,
     private val paymentRepository: PaymentRepository,
+    private val queueRepository: QueueRepository
 ) {
     @Transactional
     fun reserveConcert(reserveCommand: ReserveCommand): ReservationResult {
@@ -42,6 +44,10 @@ class ReservationService(
 
         reservation.markedAsPaid()
         reservationRepository.saveReservation(reservation)
+
+        val queueToken = queueRepository.getQueueByUuid(payCommand.tokenUuid)
+        queueToken.markedAsExpired()
+        queueRepository.saveQueueToken(queueToken)
 
         return PaymentHistoryResult.from(paymentRepository.savePaymentHistory(paymentHistory))
     }

--- a/src/main/kotlin/kr/tareun/concert/common/exception/CommonException.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/exception/CommonException.kt
@@ -1,0 +1,6 @@
+package kr.tareun.concert.common.exception
+
+class CommonException(
+    val errorCode: ErrorCode,
+    cause: Throwable? = null
+): RuntimeException(errorCode.message, cause)

--- a/src/main/kotlin/kr/tareun/concert/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/exception/ErrorCode.kt
@@ -1,0 +1,16 @@
+package kr.tareun.concert.common.exception
+
+enum class ErrorCode(val code: String, val message: String) {
+    // concert 관련 (prefix: CC)
+    CONCERT_SCHEDULE_CAPACITY_EXCEEDED("CC01", "해당 일정의 예약 가능 인원 수를 초과하였습니다."),
+
+    // payment 관련 (prefix: PM)
+    PAYMENT_NOT_ENOUGH_POINT("PM01", "잔액이 부족합니다."),
+
+    // reservation 관련 (prefix: RS)
+    RESERVATION_SEAT_ALREADY_TAKEN("RS01", "이미 예약된 좌석이 있습니다."),
+    RESERVATION_ALREADY_PAID("RS02", "이미 결제 완료된 예약입니다."),
+
+    // queue 관련 (prefix: QU)
+    QUEUE_TOKEN_EXPIRED("QU01", "만료된 토큰입니다.")
+}

--- a/src/main/kotlin/kr/tareun/concert/common/filter/LoggingFilter.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/filter/LoggingFilter.kt
@@ -1,0 +1,41 @@
+package kr.tareun.concert.common.filter
+
+import jakarta.servlet.*
+import jakarta.servlet.FilterConfig
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.util.StopWatch
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+
+@Component
+class LoggingFilter : Filter {
+
+    private val logger = LoggerFactory.getLogger(LoggingFilter::class.java)
+
+    override fun init(filterConfig: FilterConfig?) {
+    }
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        val wrappedRequest = ContentCachingRequestWrapper(request as HttpServletRequest)
+        val wrappedResponse = ContentCachingResponseWrapper(response as HttpServletResponse)
+
+        val stopWatch = StopWatch()
+        stopWatch.start()
+        chain.doFilter(wrappedRequest, wrappedResponse)
+        stopWatch.stop()
+
+        val requestBody = String(wrappedRequest.contentAsByteArray).replace(Regex("\\s+"), "")
+        val responseBody = String(wrappedResponse.contentAsByteArray)
+        logger.info("request: [${wrappedRequest.method}] ${wrappedRequest.requestURI}, Body: '$requestBody'" +
+                "response: Status=${wrappedResponse.status}, Body='${responseBody}', Duration = ${stopWatch.totalTimeMillis}")
+
+        wrappedResponse.copyBodyToResponse()
+    }
+
+    override fun destroy() {
+    }
+}

--- a/src/main/kotlin/kr/tareun/concert/domain/concert/model/ConcertSchedule.kt
+++ b/src/main/kotlin/kr/tareun/concert/domain/concert/model/ConcertSchedule.kt
@@ -1,5 +1,7 @@
 package kr.tareun.concert.domain.concert.model
 
+import kr.tareun.concert.common.exception.ErrorCode
+import kr.tareun.concert.common.exception.CommonException
 import java.time.LocalDateTime
 
 data class ConcertSchedule(
@@ -18,7 +20,7 @@ data class ConcertSchedule(
     fun addReservedCount(count: Int) {
         _reservedCount += count
         if (_reservedCount > locationCapacity) {
-            throw RuntimeException("예약 가능 인원 수를 초과하였습니다.")
+            throw CommonException(ErrorCode.CONCERT_SCHEDULE_CAPACITY_EXCEEDED)
         }
     }
 }

--- a/src/main/kotlin/kr/tareun/concert/domain/payment/model/Point.kt
+++ b/src/main/kotlin/kr/tareun/concert/domain/payment/model/Point.kt
@@ -1,5 +1,8 @@
 package kr.tareun.concert.domain.payment.model
 
+import kr.tareun.concert.common.exception.ErrorCode
+import kr.tareun.concert.common.exception.CommonException
+
 data class Point(
     val pointId: Long = 0,
     val userId: Long,
@@ -13,7 +16,7 @@ data class Point(
     }
     fun payPoint(amount: Int) {
         if (_point < amount) {
-            throw RuntimeException("잔액 부족")
+            throw CommonException(ErrorCode.PAYMENT_NOT_ENOUGH_POINT)
         }
         _point -= amount
     }

--- a/src/main/kotlin/kr/tareun/concert/domain/reservation/ReservationRepository.kt
+++ b/src/main/kotlin/kr/tareun/concert/domain/reservation/ReservationRepository.kt
@@ -5,6 +5,8 @@ import kr.tareun.concert.domain.reservation.model.ReservationItem
 
 interface ReservationRepository {
     fun getAllValidReservationItem(scheduleId: Long): List<ReservationItem>
+    fun getAllReservationItemByScheduleIdAndSeatId(scheduleId: Long, seatIds: List<Long>): List<ReservationItem>
     fun saveReservation(reservation: Reservation): Reservation
     fun getReservationByIdForUpdate(id: Long): Reservation
+    fun acquireLockByScheduleId(concertScheduleId: Long)
 }

--- a/src/main/kotlin/kr/tareun/concert/domain/reservation/model/Reservation.kt
+++ b/src/main/kotlin/kr/tareun/concert/domain/reservation/model/Reservation.kt
@@ -1,6 +1,7 @@
 package kr.tareun.concert.domain.reservation.model
 
-import java.lang.RuntimeException
+import kr.tareun.concert.common.exception.CommonException
+import kr.tareun.concert.common.exception.ErrorCode
 
 
 data class Reservation(
@@ -16,7 +17,7 @@ data class Reservation(
 
     fun markedAsPaid() {
         if (this.reservationStatus == ReservationStatusType.PAID) {
-            throw RuntimeException("이미 결제 완료된 예약입니다.")
+            throw CommonException(ErrorCode.RESERVATION_ALREADY_PAID)
         }
         this._reservationStatus = ReservationStatusType.PAID
     }

--- a/src/main/kotlin/kr/tareun/concert/domain/reservation/model/Reservation.kt
+++ b/src/main/kotlin/kr/tareun/concert/domain/reservation/model/Reservation.kt
@@ -1,5 +1,7 @@
 package kr.tareun.concert.domain.reservation.model
 
+import java.lang.RuntimeException
+
 
 data class Reservation(
     val reservationId: Long = 0,
@@ -13,6 +15,9 @@ data class Reservation(
         get() = _reservationStatus
 
     fun markedAsPaid() {
+        if (this.reservationStatus == ReservationStatusType.PAID) {
+            throw RuntimeException("이미 결제 완료된 예약입니다.")
+        }
         this._reservationStatus = ReservationStatusType.PAID
     }
 }

--- a/src/main/kotlin/kr/tareun/concert/infrastructure/persistence/reservation/ReservationItemJpaRepository.kt
+++ b/src/main/kotlin/kr/tareun/concert/infrastructure/persistence/reservation/ReservationItemJpaRepository.kt
@@ -1,8 +1,10 @@
 package kr.tareun.concert.infrastructure.persistence.reservation
 
+import jakarta.persistence.LockModeType
 import kr.tareun.concert.domain.reservation.model.ReservationStatusType
 import kr.tareun.concert.infrastructure.persistence.reservation.entity.ReservationItemEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
@@ -17,4 +19,15 @@ interface ReservationItemJpaRepository: JpaRepository<ReservationItemEntity, Lon
           AND (e.reservationStatus = :reservationStatus OR e.expiredAt < :expiredAt)
     """)
     fun findAllByScheduleIdAndStatusOrExpiredAt(scheduleId: Long, reservationStatus: ReservationStatusType, expiredAt: LocalDateTime): List<ReservationItemEntity>
+
+    @Query("""
+        SELECT e FROM ReservationItemEntity e
+        WHERE e.concertScheduleId = :scheduleId AND e.seatId IN :seatIds
+          AND (e.reservationStatus = :reservationStatus OR e.expiredAt < :expiredAt)
+    """)
+    fun findAllByScheduleIdAndSeatIdAndStatusOrExpiredAt(scheduleId: Long, seatIds: List<Long>, reservationStatus: ReservationStatusType, expiredAt: LocalDateTime): List<ReservationItemEntity>
+
+    // concertScheduleId 컬럼에 index 필수
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun findAllWithWriteLockByConcertScheduleId(scheduleId: Long): List<ReservationItemEntity>
 }

--- a/src/main/kotlin/kr/tareun/concert/infrastructure/persistence/reservation/ReservationRepositoryImpl.kt
+++ b/src/main/kotlin/kr/tareun/concert/infrastructure/persistence/reservation/ReservationRepositoryImpl.kt
@@ -22,6 +22,11 @@ class ReservationRepositoryImpl (
         return itemList.map { it.toReservationItem() }
     }
 
+    override fun getAllReservationItemByScheduleIdAndSeatId(scheduleId: Long, seatIds: List<Long>): List<ReservationItem> {
+        return reservationItemJpaRepository.findAllByScheduleIdAndSeatIdAndStatusOrExpiredAt(scheduleId, seatIds, ReservationStatusType.PAID, LocalDateTime.now())
+            .map { it.toReservationItem() }
+    }
+
     override fun saveReservation(reservation: Reservation): Reservation {
         val reservationEntity = ReservationEntity.from(reservation)
         val reservationResult = reservationJpaRepository.save(reservationEntity)
@@ -42,5 +47,9 @@ class ReservationRepositoryImpl (
         val reservationEntity = reservationJpaRepository.getReferenceById(id)
         val items = reservationItemJpaRepository.findAllByReservationId(reservationEntity.id)
         return reservationEntity.toReservation(items)
+    }
+
+    override fun acquireLockByScheduleId(concertScheduleId: Long) {
+        reservationItemJpaRepository.findAllWithWriteLockByConcertScheduleId(concertScheduleId)
     }
 }

--- a/src/main/kotlin/kr/tareun/concert/interfaces/common/advice/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/kr/tareun/concert/interfaces/common/advice/GlobalExceptionHandler.kt
@@ -1,0 +1,25 @@
+package kr.tareun.concert.interfaces.common.advice
+
+import kr.tareun.concert.common.exception.CommonException
+import kr.tareun.concert.interfaces.common.response.Response
+import kr.tareun.concert.interfaces.common.response.ResponseResultType
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    @ExceptionHandler(CommonException::class)
+    fun handleCommonException(commonException: CommonException): Response<String> {
+        logger.error("error: ${commonException.errorCode.code} - ${commonException.message}", commonException)
+
+        return Response(
+            result = ResponseResultType.ERROR,
+            item = commonException.errorCode.code,
+            message = commonException.message,
+        )
+    }
+}

--- a/src/main/kotlin/kr/tareun/concert/interfaces/reservation/ReservationController.kt
+++ b/src/main/kotlin/kr/tareun/concert/interfaces/reservation/ReservationController.kt
@@ -10,6 +10,7 @@ import kr.tareun.concert.interfaces.payment.model.PaymentHistoryResponse
 import kr.tareun.concert.interfaces.reservation.model.ReservationResponse
 import kr.tareun.concert.interfaces.reservation.model.ReserveRequest
 import org.springframework.web.bind.annotation.*
+import java.util.UUID
 
 @RequestMapping("/reservation")
 @RestController
@@ -27,8 +28,8 @@ class ReservationController(
     }
 
     @PostMapping("/pay")
-    fun payReservedConcert(@RequestBody payRequest: PayRequest): Response<PaymentHistoryResponse> {
-        val command = PayCommand.from(payRequest)
+    fun payReservedConcert(@RequestBody payRequest: PayRequest, @RequestHeader("Queue-Token") tokenUuid: UUID): Response<PaymentHistoryResponse> {
+        val command = PayCommand.from(payRequest, tokenUuid)
         return Response(
             ResponseResultType.SUCCESS,
             PaymentHistoryResponse.from(reservationService.payReservation(command))

--- a/src/test/kotlin/kr/tareun/concert/concert/ConcertScheduleUnitTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/concert/ConcertScheduleUnitTest.kt
@@ -1,0 +1,54 @@
+package kr.tareun.concert.concert
+
+import kr.tareun.concert.common.exception.ErrorCode
+import kr.tareun.concert.common.exception.CommonException
+import kr.tareun.concert.domain.concert.model.ConcertSchedule
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+@Suppress("NonAsciiCharacters")
+class ConcertScheduleUnitTest {
+
+    @Test
+    fun `콘서트 일정에 예매 횟수를 추가 할 수 있다`() {
+        // given
+        val schedule = ConcertSchedule(
+            concertId = 1,
+            scheduleId = 1,
+            ticketPrice = 10000,
+            scheduledDate = LocalDateTime.now().plusDays(1),
+            locationId = 1,
+            locationName = "공연장 1",
+            locationCapacity = 100,
+            _reservedCount = 99
+        )
+
+        // when
+        schedule.addReservedCount(1)
+
+        // then
+        Assertions.assertEquals(100 , schedule.reservedCount)
+    }
+
+    @Test
+    fun `콘서트 예매시 최대 횟수를 초과할 경우 에러 코드 CONCERT_SCHEDULE_CAPACITY_EXCEEDED 를 던진다`() {
+        // when
+        val schedule = ConcertSchedule(
+            concertId = 1,
+            scheduleId = 1,
+            ticketPrice = 10000,
+            scheduledDate = LocalDateTime.now().plusDays(1),
+            locationId = 1,
+            locationName = "공연장 1",
+            locationCapacity = 100,
+            _reservedCount = 100
+        )
+
+        // when - then
+        val thrown = Assertions.assertThrows(CommonException::class.java) {
+            schedule.addReservedCount(1)
+        }
+        Assertions.assertEquals(ErrorCode.CONCERT_SCHEDULE_CAPACITY_EXCEEDED, thrown.errorCode)
+    }
+}

--- a/src/test/kotlin/kr/tareun/concert/payment/PointUnitTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/payment/PointUnitTest.kt
@@ -1,0 +1,48 @@
+package kr.tareun.concert.payment
+
+import kr.tareun.concert.common.exception.ErrorCode
+import kr.tareun.concert.common.exception.CommonException
+import kr.tareun.concert.domain.payment.model.Point
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@Suppress("NonAsciiCharacters")
+class PointUnitTest {
+
+    @Test
+    fun `잔액을 충전 할 수 있다`() {
+        // when
+        val point = Point(1, 1, 10_000)
+
+        // when
+        point.chargePoint(10_000)
+
+        // then
+        Assertions.assertEquals(20_000, point.point)
+    }
+
+    @Test
+    fun `잔액을 사용할 수 있다`() {
+        // given
+        val point = Point(1, 1, 10_000)
+
+        // when
+        point.payPoint(10_000)
+
+        // then
+        Assertions.assertEquals(0, point.point)
+    }
+
+    @Test
+    fun `잔액이 부족할 경우 에러코드 PAYMENT_NOT_ENOUGH_POINT 를 던진다`() {
+        // given
+        val point = Point(1, 1, 10_000)
+
+        // when - then
+        val thrown = Assertions.assertThrows(CommonException::class.java) {
+            point.payPoint(10_001)
+        }
+        Assertions.assertEquals(ErrorCode.PAYMENT_NOT_ENOUGH_POINT, thrown.errorCode)
+
+    }
+}

--- a/src/test/kotlin/kr/tareun/concert/queue/QueueTokenUnitTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/queue/QueueTokenUnitTest.kt
@@ -1,0 +1,63 @@
+package kr.tareun.concert.queue
+
+import kr.tareun.concert.domain.queue.model.QueueToken
+import kr.tareun.concert.domain.queue.model.TokenStatusType
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+@Suppress("NonAsciiCharacters")
+class QueueTokenUnitTest {
+
+    @Test
+    fun `대기열 토큰을 만료 처리 할 수 있다`() {
+        // given
+        val token = QueueToken(
+            tokenId = 1,
+            userId = 1,
+            uuid = UUID.fromString("9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"),
+            _status = TokenStatusType.PENDING,
+        )
+
+        // when
+        token.markedAsExpired()
+
+        // then
+        Assertions.assertEquals(TokenStatusType.EXPIRED, token.status)
+    }
+
+    @Test
+    fun `대기열 토큰을 활성화 처리 할 수 있다`() {
+        // given
+        val token = QueueToken(
+            tokenId = 1,
+            userId = 1,
+            uuid = UUID.fromString("9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"),
+            _status = TokenStatusType.PENDING,
+        )
+
+        // when
+        token.markedAsActivated()
+
+        // then
+        Assertions.assertEquals(TokenStatusType.ACTIVATED, token.status)
+    }
+
+    @Test
+    fun `대기열 토큰의 만료 시간을 설정할 수 있다`() {
+        // given
+        val token = QueueToken(
+            tokenId = 1,
+            userId = 1,
+            uuid = UUID.fromString("9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"),
+            _status = TokenStatusType.ACTIVATED,
+        )
+
+        // when
+        token.updateExpiredTime(LocalDateTime.now().plusMinutes(15))
+
+        // then
+        Assertions.assertNotNull(token.expiredTime)
+    }
+}

--- a/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.springframework.jdbc.datasource.init.ScriptUtils
 import java.sql.SQLException
 import java.util.*
 import java.util.Arrays.asList
+import java.util.concurrent.CompletableFuture
 
 @Suppress("NonAsciiCharacters")
 @SpringBootTest
@@ -57,5 +58,51 @@ class ReservationServiceIntegrationTest {
 
         // when - then
         Assertions.assertEquals(userId, reservationService.payReservation(reserveCommand).userId)
+    }
+
+    @Test
+    fun `하나의 좌석에 대해 여러번 예약 요청이 들어왔을 경우 하나만 성공한다`() {
+        // given
+        val reserveCommand = ReserveCommand(1, 1, listOf(4L))
+
+        // when
+        val futures = (1..10).map {
+            CompletableFuture.supplyAsync {
+                try {
+                    reservationService.reserveConcert(reserveCommand)
+                    true
+                } catch (e: Exception) {
+                    false
+                }
+            }
+        }
+        val results = futures.map { it.join() }
+
+        // then
+        val successfulReservations = results.count { it }
+        Assertions.assertEquals(1, successfulReservations)
+    }
+
+    @Test
+    fun `하나의 예약에 대해 여러번 결제 요청이 들어왔을 경우 하나만 성공한다`() {
+        // given
+        val payCommand = PayCommand(userId = 1, reservationId = 1)
+
+        // when
+        val futures = (1..10).map {
+            CompletableFuture.supplyAsync {
+                try {
+                    reservationService.payReservation(payCommand)
+                    true
+                } catch (e: Exception) {
+                    false
+                }
+            }
+        }
+        val results = futures.map { it.join() }
+
+        // then
+        val successfulReservations = results.count { it }
+        Assertions.assertEquals(1, successfulReservations)
     }
 }

--- a/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceIntegrationTest.kt
@@ -12,6 +12,7 @@ import org.springframework.core.io.ClassPathResource
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.datasource.init.ScriptUtils
 import java.sql.SQLException
+import java.util.*
 import java.util.Arrays.asList
 
 @Suppress("NonAsciiCharacters")
@@ -51,7 +52,8 @@ class ReservationServiceIntegrationTest {
         // given
         val userId = 1L
         val reservationId = 1L
-        val reserveCommand = PayCommand(userId, reservationId)
+        val tokenUuid = UUID.fromString("9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")
+        val reserveCommand = PayCommand(userId, reservationId, tokenUuid)
 
         // when - then
         Assertions.assertEquals(userId, reservationService.payReservation(reserveCommand).userId)

--- a/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceUnitTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceUnitTest.kt
@@ -8,6 +8,8 @@ import kr.tareun.concert.domain.concert.model.ConcertSchedule
 import kr.tareun.concert.domain.payment.PaymentRepository
 import kr.tareun.concert.domain.payment.model.PaymentHistory
 import kr.tareun.concert.domain.payment.model.Point
+import kr.tareun.concert.domain.queue.QueueRepository
+import kr.tareun.concert.domain.queue.model.QueueToken
 import kr.tareun.concert.domain.reservation.ReservationRepository
 import kr.tareun.concert.domain.reservation.model.Reservation
 import kr.tareun.concert.domain.reservation.model.ReservationStatusType
@@ -20,6 +22,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import java.time.LocalDateTime
+import java.util.*
 
 @Suppress("NonAsciiCharacters")
 class ReservationServiceUnitTest {
@@ -31,6 +34,9 @@ class ReservationServiceUnitTest {
 
     @Mock
     private lateinit var paymentRepository: PaymentRepository
+
+    @Mock
+    private lateinit var queueRepository: QueueRepository
 
     @InjectMocks
     private lateinit var reservationService: ReservationService
@@ -66,12 +72,14 @@ class ReservationServiceUnitTest {
         val point = Point(1, userId, basePoint)
         val reservation = Reservation(reservationId, userId, 1, listOf(1), 10_000, ReservationStatusType.NON_PAID)
         val paymentHistory = PaymentHistory(1, userId, reservationId, reservation.priceAmount)
-
-        val payRequest = PayCommand(userId, reservationId)
+        val tokenUuid = UUID.fromString("9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")
+        val payRequest = PayCommand(userId, reservationId, tokenUuid)
+        val queueToken = QueueToken(1, 1, tokenUuid)
 
         `when`(paymentRepository.getPointByUserIdForUpdate(userId)).thenReturn(point)
         `when`(reservationRepository.getReservationByIdForUpdate(reservationId)).thenReturn(reservation)
         `when`(paymentRepository.savePaymentHistory(any())).thenReturn(paymentHistory)
+        `when`(queueRepository.getQueueByUuid(tokenUuid)).thenReturn(queueToken)
 
         // when
         val result = reservationService.payReservation(payRequest)

--- a/src/test/kotlin/kr/tareun/concert/reservation/ReservationUnitTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/reservation/ReservationUnitTest.kt
@@ -1,0 +1,51 @@
+package kr.tareun.concert.reservation
+
+import kr.tareun.concert.common.exception.CommonException
+import kr.tareun.concert.common.exception.ErrorCode
+import kr.tareun.concert.domain.reservation.model.Reservation
+import kr.tareun.concert.domain.reservation.model.ReservationStatusType
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@Suppress("NonAsciiCharacters")
+class ReservationUnitTest {
+    @Test
+    fun `예약 내역을 결제 완료 처리 할 수 있다`() {
+        // given
+        val reservation = Reservation(
+            reservationId = 1,
+            userId = 1,
+            concertScheduleId = 1,
+            seatIds = listOf(1, 2),
+            priceAmount = 20_000,
+            _reservationStatus = ReservationStatusType.NON_PAID
+        )
+
+        // when
+        reservation.markedAsPaid()
+
+        // then
+        Assertions.assertEquals(ReservationStatusType.PAID, reservation.reservationStatus)
+    }
+
+    @Test
+    fun `이미 결제 완료된 예약을 결제할 경우 에러코드 RESERVATION_ALREADY_PAID 을 던진다`() {
+        // given
+        val reservation = Reservation(
+            reservationId = 1,
+            userId = 1,
+            concertScheduleId = 1,
+            seatIds = listOf(1, 2),
+            priceAmount = 20_000,
+            _reservationStatus = ReservationStatusType.PAID
+        )
+
+        // when
+        val thrown = Assertions.assertThrows(CommonException::class.java) {
+            reservation.markedAsPaid()
+        }
+
+        // then
+        Assertions.assertEquals(ErrorCode.RESERVATION_ALREADY_PAID, thrown.errorCode)
+    }
+}

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -27,6 +27,7 @@ CREATE TABLE reservation_item
     expired_at          TIMESTAMP             NOT NULL,
     CONSTRAINT pk_reservation_item PRIMARY KEY (id)
 );
+CREATE INDEX idx_concert_schedule_id ON reservation_item (concert_schedule_id);
 
 DROP TABLE IF EXISTS queue_token;
 CREATE TABLE queue_token


### PR DESCRIPTION
Chapter 2 회고
https://tareun.notion.site/Chapter-2-API-17d987f1cade8017b7d9ff646babe295


### **커밋 링크**
동시성 처리 및 통합 테스트: b952cfc
커스텀 예외 추가, 도메인 단위 테스트 추가: 0bcef79
글로벌 예외 핸들링: 24c5f10
로깅 필터 추가: 2ec2b66

---
### **리뷰 포인트(질문)**
- ReservationService 에서 좌석을 예약할때 이미 예약된 좌석인지 확인하는 로직에서 예외를 던지고 있는데요.
도메인 객체를 통해 던지기가 어려워 Service 에서 던지게 되었는데 자연스러운 부분인지 확인 부탁드립니다.
https://github.com/Tareun3406/hhplus-concert/pull/3/files#diff-c06e216943d03aa0ad5e3e175f33a9004beb508e2b8824491589c75e4364f72e
---
