### PR TITLE
feat: redis 분산락 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
 
 	//swagger
 	implementation ("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+
+	// lock
+	implementation("org.redisson:redisson-spring-boot-starter:3.43.0")
 }
 
 kotlin {

--- a/src/main/kotlin/kr/tareun/concert/common/aop/RedisLockAop.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/aop/RedisLockAop.kt
@@ -1,0 +1,48 @@
+package kr.tareun.concert.common.aop
+
+import kr.tareun.concert.common.aop.annotaion.RedisLock
+import kr.tareun.concert.common.aop.util.CustomSpringELParser
+import kr.tareun.concert.common.exception.RedisLockException
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RedissonClient
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE - 1) // @Transactional 의 order=Ordered.LOWEST_PRECEDENCE
+class RedisLockAop(private val redissonClient: RedissonClient) {
+    private val customSpringELParser = CustomSpringELParser()
+
+    @Around("@annotation(redisLock)")
+    fun handleLock(joinPoint: ProceedingJoinPoint, redisLock: RedisLock): Any {
+        val methodSignature = joinPoint.signature as MethodSignature
+        val methodParameterNames =methodSignature.method.parameters.map { it.name }.toTypedArray()
+        val methodArgs = joinPoint.args
+
+        val keys = customSpringELParser.parseSpELKeys(redisLock.prefix, redisLock.variableKeys, methodArgs, methodParameterNames)
+        val locks = keys.sorted().map {redissonClient.getLock(it)}.toTypedArray() // 정렬이 없을 경우 데드락 발생 가능
+        val multiLock = redissonClient.getMultiLock(*locks)
+
+        // 락 획득 대기 10초, 획득후 ttl 초 유지
+        val isLockAcquired = multiLock.tryLock(10, redisLock.ttlSec, java.util.concurrent.TimeUnit.SECONDS)
+        return try {
+            if (isLockAcquired) {
+                // 락 획득 성공 시 메서드 실행
+                joinPoint.proceed()
+            } else {
+                throw RedisLockException("Could not acquire lock for key : prefix - ${redisLock.prefix}, variable - $keys")
+            }
+        } finally {
+            if (isLockAcquired) {
+                multiLock.unlock() // 락 해제
+            }
+        }
+    }
+}

--- a/src/main/kotlin/kr/tareun/concert/common/aop/annotaion/RedisLock.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/aop/annotaion/RedisLock.kt
@@ -1,0 +1,9 @@
+package kr.tareun.concert.common.aop.annotaion
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RedisLock(
+    val prefix: String = "",
+    val variableKeys: Array<String>,
+    val ttlSec: Long
+)

--- a/src/main/kotlin/kr/tareun/concert/common/aop/util/CustomSpringELParser.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/aop/util/CustomSpringELParser.kt
@@ -1,0 +1,27 @@
+package kr.tareun.concert.common.aop.util
+
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+
+class CustomSpringELParser {
+    fun parseSpELKeys(prefix: String, variableKeys: Array<String>, args: Array<Any>, parameterNames: Array<String>): List<String> {
+        val context = StandardEvaluationContext()
+        val spELParser = SpelExpressionParser()
+
+        // 메서드 매개변수와 값 매핑
+        args.forEachIndexed { index, arg ->
+            context.setVariable(parameterNames[index], arg)
+        }
+
+        // SpEL 키 파싱 및 결과 생성
+        val parsedPrefix = spELParser.parseExpression(prefix).getValue(context, String::class.java)
+        return variableKeys.flatMap { key ->
+            val parsedKey = spELParser.parseExpression(key).getValue(context, Any::class.java)
+            when (parsedKey) {
+                is Collection<*> -> parsedKey.map { parsedPrefix + it.toString() } // List나 Set인 경우 각각의 값을 사용
+                is Array<*> -> parsedKey.map { parsedPrefix + it.toString() } // 배열인 경우 각각의 값을 사용
+                else -> listOf(parsedPrefix + (parsedKey?.toString() ?: key)) // 단일 값 처리
+            }
+        }
+    }
+}

--- a/src/main/kotlin/kr/tareun/concert/common/config/RedisProperties.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/config/RedisProperties.kt
@@ -1,0 +1,11 @@
+package kr.tareun.concert.common.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "spring.redis")
+class RedisProperties {
+    var host = "localhost"
+    var port = 6379
+}

--- a/src/main/kotlin/kr/tareun/concert/common/config/RedissonConfig.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/config/RedissonConfig.kt
@@ -1,0 +1,19 @@
+package kr.tareun.concert.common.config
+
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RedissonConfig(redisProperties: RedisProperties) {
+    val redissonHostUrl = "redis://${redisProperties.host}:${redisProperties.port}"
+
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val config = Config()
+        config.useSingleServer().address = redissonHostUrl
+        return Redisson.create(config)
+    }
+}

--- a/src/main/kotlin/kr/tareun/concert/common/exception/RedisLockException.kt
+++ b/src/main/kotlin/kr/tareun/concert/common/exception/RedisLockException.kt
@@ -1,0 +1,3 @@
+package kr.tareun.concert.common.exception
+
+class RedisLockException(message: String) : RuntimeException(message)

--- a/src/test/kotlin/kr/tareun/concert/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/kr/tareun/concert/TestcontainersConfiguration.kt
@@ -1,13 +1,15 @@
 package kr.tareun.concert
 
+import kr.tareun.concert.common.config.RedisProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.jdbc.datasource.DriverManagerDataSource
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.MariaDBContainer
 import org.testcontainers.utility.DockerImageName
 import javax.sql.DataSource
 
-@Configuration(proxyBeanMethods = false)
+@Configuration
 class TestcontainersConfiguration {
 
 	@Bean
@@ -25,5 +27,21 @@ class TestcontainersConfiguration {
 		dataSource.username = mariaDbContainer.username
 		dataSource.password = mariaDbContainer.password
 		return dataSource
+	}
+
+	@Bean
+	fun redisContainer(): GenericContainer<*> {
+		return GenericContainer(DockerImageName.parse("redis:7.4"))
+			.withExposedPorts(6379) // Redis 기본 포트
+			.withReuse(false)
+			.apply { start() }
+	}
+
+	@Bean
+	fun redisProperties(redisContainer: GenericContainer<*>): RedisProperties {
+		val redisProperties = RedisProperties()
+		redisProperties.host = redisContainer.host
+		redisProperties.port = redisContainer.getMappedPort(6379)
+		return redisProperties
 	}
 }

--- a/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceIntegrationTest.kt
+++ b/src/test/kotlin/kr/tareun/concert/reservation/ReservationServiceIntegrationTest.kt
@@ -86,7 +86,7 @@ class ReservationServiceIntegrationTest {
     @Test
     fun `하나의 예약에 대해 여러번 결제 요청이 들어왔을 경우 하나만 성공한다`() {
         // given
-        val payCommand = PayCommand(userId = 1, reservationId = 1)
+        val payCommand = PayCommand(userId = 1, reservationId = 1, tokenUuid = UUID.fromString("9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"))
 
         // when
         val futures = (1..10).map {


### PR DESCRIPTION
### **커밋 링크**
레디스 분산락 적용 : d819b28
락 적용 문서: https://github.com/Tareun3406/hhplus-concert/blob/main/docs/lock.md

---
### **리뷰 포인트(질문)**
결제 아이템 리스트가 존재하기 때문에 Multi Lock 을 사용해 보았습니다.
따로 알아보니 여러개의 키를 Multi Lock 으로 묶어도 실제로는 하나씩 락을 획득하는 것 같은데요. 데드락이 발생할 수도 있지 않을까 하는 생각이 들었습니다.

그래서 별도의 queue 를 도입해서 사용하자니 scheduleId 를 기준으로 락을 만드는게 더 효율적일 것 같아서 고민했습니다.
그러다 Muiti Lock 에 사용되는 키들의 락 획득 순서를 정렬 해주면 데드락 자체는 방지가 되지 않을까 하는 생각이 들어 그렇게 적용해 보았는데, 혹시 이 부분에서 제가 놓친 부분이 없을지 혹은 더 좋은방법이 있는지 체크 부탁드립니다. 